### PR TITLE
Webhook Response Enhancement

### DIFF
--- a/pkg/handlers/webhook/webhook.go
+++ b/pkg/handlers/webhook/webhook.go
@@ -50,7 +50,17 @@ type Webhook struct {
 
 // WebhookMessage for messages
 type WebhookMessage struct {
-	Text string `json:"text"`
+	EventMeta EventMeta `json:"eventmeta"`
+	Message   string    `json:"message"`
+	Time      time.Time `json:"time"`
+}
+
+// EventMeta containes the meta data about the event occurred
+type EventMeta struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Reason    string `json:"reason"`
 }
 
 // Init prepares Webhook configuration
@@ -85,7 +95,14 @@ func (m *Webhook) ObjectUpdated(oldObj, newObj interface{}) {
 func (m *Webhook) TestHandler() {
 
 	webhookMessage := &WebhookMessage{
-		"Testing Handler Configuration. This is a Test message.",
+		EventMeta: EventMeta{
+			Kind:      "object",
+			Name:      "Test",
+			Namespace: "default",
+			Reason:    "Tested",
+		},
+		Message: "Testing Handler Configuration. This is a Test message.",
+		Time:    time.Now(),
 	}
 
 	err := postMessage(m.Url, webhookMessage)
@@ -121,9 +138,15 @@ func checkMissingWebhookVars(s *Webhook) error {
 
 func prepareWebhookMessage(e kbEvent.Event, m *Webhook) *WebhookMessage {
 	return &WebhookMessage{
-		e.Message(),
+		EventMeta: EventMeta{
+			Kind:      e.Kind,
+			Name:      e.Name,
+			Namespace: e.Namespace,
+			Reason:    e.Reason,
+		},
+		Message: e.Message(),
+		Time:    time.Now(),
 	}
-
 }
 
 func postMessage(url string, webhookMessage *WebhookMessage) error {


### PR DESCRIPTION
This PR,
- Enhances the webhook JSON Payload
- Adds EventMeta, Message,Time fields to JSON response.

changes the current JSON payload 

from
```
{
"text" : "A `pod` in namespace `sample-app` has been `Deleted`:\n`sample-app/yelb-ui-5946c9cfdb-gqpbb`"
}
```
to
```JSON
{
  "eventmeta": {
    "kind": "object",
    "name": "Test",
    "namespace": "default",
    "reason": "Tested"
  },
  "message": "Testing Handler Configuration. This is a Test message.",
  "time": "2019-07-18T15:29:48.677368507+05:30"
}
```